### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -1,0 +1,40 @@
+# Kubernetes controllers
+
+### Описание
+
+Выполнены следующие действия:
+- добавлен манифест `namespace.yaml` для `namespace` с именем `homework`
+- добавлен манифест `deployment.yaml`, который:
+    - создается в `namespace` `homework`
+    - запускает 3 экземпляра пода, аналогичных по спецификации из
+    задания [kubernetes-intro](../kubernetes-intro/pod.yaml)
+    - в дополнение к этому поды имеют `readiness пробу`, проверяющую 
+    наличие файла `/homework/index.html`
+    - имеет стратегию обновления `RollingUpdate`, настроенная так, что в 
+    процессе обновления может быть недоступен максимум 1 под
+    - `*` добавлен `nodeSelector`, обеспечивающий запуск подов только на
+    ноде, имеющей лейбл `homework=true`
+
+### Запуск
+
+Применить манифесты:
+```shell
+kubectl apply -f namespace.yaml -f configmap.yaml -f deployment.yaml
+```
+
+Поды будут находится в статусе `Pending`, т.к. в кластере нет нод с лейблом `homework=true`. Нужно добавить лейбл на любую ноду:
+```shell
+kubectl label node kind-worker homework=true
+```
+
+После этого поды назначатся на эту ноду и запустятся на ней, можно убедиться:
+```shell
+kubectl -n homework get po
+```
+
+Для проверки раскатки деплоя, можно поменять версию контейнера в описании
+пода и посмотреть как это будет раскатываться:
+```shell
+kubectl -n homework set image deployments web-server nginx-container=nginx:1.28
+kubectl -n homework get po -w
+```

--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -7,7 +7,7 @@
 - добавлен манифест `deployment.yaml`, который:
     - создается в `namespace` `homework`
     - запускает 3 экземпляра пода, аналогичных по спецификации из
-    задания [kubernetes-intro](../blob/main/kubernetes-intro/pod.yaml)
+    задания [kubernetes-intro](/kubernetes-intro/pod.yaml)
     - в дополнение к этому поды имеют `readiness пробу`, проверяющую 
     наличие файла `/homework/index.html`
     - имеет стратегию обновления `RollingUpdate`, настроенная так, что в 

--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -22,7 +22,8 @@
 kubectl apply -f namespace.yaml -f configmap.yaml -f deployment.yaml
 ```
 
-Поды будут находится в статусе `Pending`, т.к. в кластере нет нод с лейблом `homework=true`. Нужно добавить лейбл на любую ноду:
+Поды будут находится в статусе `Pending`, т.к. в кластере нет нод с лейблом `homework=true`.
+Нужно добавить лейбл на любую ноду:
 ```shell
 kubectl label node kind-worker homework=true
 ```
@@ -37,4 +38,10 @@ kubectl -n homework get po
 ```shell
 kubectl -n homework set image deployments web-server nginx-container=nginx:1.28
 kubectl -n homework get po -w
+```
+
+Для проверки работы `readiness пробы` можно удалить файл `/homework/index.html` в каком-нибудь
+поде и увидеть, что проба провалится:
+```shell
+kubectl -n homework exec web-server-7b77d94ddf-f6tf8 -c nginx-container -- bash -c "rm /homework/index.html"
 ```

--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -7,7 +7,7 @@
 - добавлен манифест `deployment.yaml`, который:
     - создается в `namespace` `homework`
     - запускает 3 экземпляра пода, аналогичных по спецификации из
-    задания [kubernetes-intro](../kubernetes-intro/pod.yaml)
+    задания [kubernetes-intro](../blob/main/kubernetes-intro/pod.yaml)
     - в дополнение к этому поды имеют `readiness пробу`, проверяющую 
     наличие файла `/homework/index.html`
     - имеет стратегию обновления `RollingUpdate`, настроенная так, что в 

--- a/kubernetes-controllers/configmap.yaml
+++ b/kubernetes-controllers/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+      listen       8000;
+      server_name  localhost;
+      location / {
+          root   /homework;
+          index  index.html index.htm;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+    }

--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             command:
             - cat
             - /homework/index.html
-          initialDelaySeconds: 5
+          initialDelaySeconds: 1
           periodSeconds: 5
       volumes:
       - name: homework-volume

--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      nodeSelector:
+        homework: "true"
+      initContainers:
+      - name: init-page
+        image: busybox:1.36.1
+        command: ['sh', '-c', 'wget https://www.rancher.com/ -O /init/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /init
+      containers:
+      - name: nginx-container
+        image: nginx:1.29
+        ports:
+        - containerPort: 8000
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm', '/homework/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /homework
+        - name: config
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /homework/index.html
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: homework-volume
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: nginx-config
+          items:
+          - key: default.conf
+            path: default.conf

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - добавлен манифест `namespace.yaml` для `namespace` с именем `homework`
 - добавлен манифест `deployment.yaml`, который:
    - создается в `namespace` `homework`
    - запускает 3 экземпляра пода, аналогичных по спецификации из
    задания [kubernetes-intro](/kubernetes-intro/pod.yaml)
    - в дополнение к этому поды имеют `readiness пробу`, проверяющую 
    наличие файла `/homework/index.html`
    - имеет стратегию обновления `RollingUpdate`, настроенная так, что в 
    процессе обновления может быть недоступен максимум 1 под
    - `*` добавлен `nodeSelector`, обеспечивающий запуск подов только на
    ноде, имеющей лейбл `homework=true`

## Как запустить проект:
 - добавить метку ноде `kubectl label node kind-worker homework=true`
 - применить манифесты `kubectl apply -f namespace.yaml -f configmap.yaml -f deployment.yaml`

## Как проверить работоспособность:
 - проверить, что поды развернулись и назначились на нужную ноду `kubectl -n homework get po -o wide`
 - пробросить порт из контейнера `kubectl -n homework port-forward pods/web-server-7b77d94ddf-x7zgd 8000 8000` и перейти на http://localhost:8000/

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
