### PR TITLE
Kubernetes networks

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,33 @@
+# Kubernetes networks
+
+### Описание
+
+Выполнены следующие действия:
+- изменена `readiness-проба` в манифесте `deployment.yaml` из 
+[прошлого ДЗ](/kubernetes-controllers/deployment.yaml) на `httpGet`,
+вызывающая URL `/index.html`
+- добавлен манифест `service.yaml`, описывающий сервис типа `ClusterIP`, который направляет трафик на поды,
+управляемые `deployment`
+- установлен `ingress-контроллер` `nginx` в кластер (`minikube addons enable ingress`)
+- добавлен манифест `ingress.yaml`, в котором описан объект типа `ingress`, направляющий
+все http запросы к хосту `homework.otus` на созданный сервис
+- `*` в манифест `ingress.yaml` добавлены rewrite-правила для форвардинга запросов с `/homepage` на `/`
+
+### Запуск
+
+Применить все манифесты:
+```shell
+kubectl apply -f namespace.yaml -f configmap.yaml -f deployment.yaml -f service.yaml -f ingress.yaml
+```
+Для запуска на `minikube` нужно установить ingress-контроллер:
+```shell
+minikube addons enable ingress
+```
+и запустить тоннель:
+```shell
+minikube tunnel --bind-address=127.0.0.1
+```
+Добавить хост `homework.otus` в `/etc/hosts`.
+
+Для проверки перейти по адресу http://homework.otus. Чтобы проверить
+форвардинг, перейти на http://homework.otus/homepage

--- a/kubernetes-networks/configmap.yaml
+++ b/kubernetes-networks/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+      listen       8000;
+      server_name  localhost;
+      location / {
+          root   /homework;
+          index  index.html index.htm;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+    }

--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      initContainers:
+      - name: init-page
+        image: busybox:1.36.1
+        command: ['sh', '-c', 'wget https://www.rancher.com/ -O /init/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /init
+      containers:
+      - name: nginx-container
+        image: nginx:1.29
+        ports:
+        - containerPort: 8000
+          name: http
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm', '/homework/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /homework
+        - name: config
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 1
+          periodSeconds: 5
+      volumes:
+      - name: homework-volume
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: nginx-config
+          items:
+          - key: default.conf
+            path: default.conf

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,6 +1,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
   name: web-server
   namespace: homework
 spec:
@@ -15,4 +17,11 @@ spec:
           service:
             name: web-server
             port: 
+              name: http
+      - path: /homepage$
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: web-server
+            port:
               name: http

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-server
+            port: 
+              name: http

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app: web-server
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - изменена `readiness-проба` в манифесте `deployment.yaml` из [прошлого ДЗ](https://github.com/Kuber-2025-06OTUS/lex-r_repo/blob/main/kubernetes-controllers/deployment.yaml) на `httpGet`, вызывающая URL `/index.html`
 - добавлен манифест `service.yaml`, описывающий сервис типа `ClusterIP`, который направляет трафик на поды,
управляемые `deployment`
- установлен `ingress-контроллер` `nginx` в кластер (`minikube addons enable ingress`)
- добавлен манифест `ingress.yaml`, в котором описан объект типа `ingress`, направляющий
все http запросы к хосту `homework.otus` на созданный сервис
- `*` в манифест `ingress.yaml` добавлены rewrite-правила для форвардинга запросов с `/homepage` на `/`

## Как запустить проект:
 - установить ingress-контроллер `minikube addons enable ingress` 
 - применить все манифесты `kubectl apply -f namespace.yaml -f configmap.yaml -f deployment.yaml -f service.yaml -f ingress.yaml`
 - запустить тоннель `minikube tunnel --bind-address=127.0.0.1`
 - добавить хост `homework.otus` в `/etc/hosts`

## Как проверить работоспособность:
 - перейти по адресу http://homework.otus
 - для проверки форвардинга - перейти на http://homework.otus/homepage

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
