### PR TITLE
add kubernetes-volumes

### DIFF
--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,39 @@
+# Kubernetes volumes
+
+### Описание
+
+Выполнены следующие действия:
+- создан манифест `pvc.yaml`, описывающий `PersistentVolumeClaim`, запрашивающий
+хранилище с `storageClass` по-умолчанию
+- создан манифест `configmap.yaml` для объекта типа `configMap`, описывающий
+конфиг для nginx и дополнительный набор пар ключ-значение
+- в манифесте `deployment.yaml` изменена спецификация volume типа `emptyDir`, 
+который монтируется в init и основной контейнер, на `pvc`, созданный в 
+предыдущем пункте
+- в манифесте `deployment.yaml` добавлено монтирование ранее созданного configMap
+как volume к основному контейнеру пода в директорию `/homework/conf`, так, чтобы 
+его содержимое можно было получить, обратившись по url `/conf/key`
+- `*` создан манифест storageClass.yaml, описывающий объкт типа storageClass с
+provisioner `k8s.io/minikube-hostpath` и `reclaimPolicy` `Retain`
+- `*` изменен манифест pvc.yaml так, чтобы в нем запрашивалось хранилище,
+созданное в предыдущем пункте
+
+### Запуск
+
+Применить все манифесты:
+```shell
+kubectl apply -f namespace.yaml -f configmap.yaml -f storageClass.yaml -f pvc.yaml -f deployment.yaml -f service.yaml -f ingress.yaml
+```
+Для запуска на `minikube` нужно установить ingress-контроллер:
+```shell
+minikube addons enable ingress
+```
+и запустить тоннель:
+```shell
+minikube tunnel --bind-address=127.0.0.1
+```
+Добавить хост `homework.otus` в `/etc/hosts`.
+
+Для проверки:
+- перейти по адресу http://homework.otus
+- перейти по адресу http://homework.otus/conf/key

--- a/kubernetes-volumes/configmap.yaml
+++ b/kubernetes-volumes/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+      listen       8000;
+      server_name  localhost;
+      location / {
+          root   /homework;
+          index  index.html index.htm;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+    }
+  key: value
+  someKey: someValue

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      initContainers:
+      - name: init-page
+        image: busybox:1.36.1
+        command: ['sh', '-c', 'wget https://www.rancher.com/ -O /init/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /init
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 100Mi
+      containers:
+      - name: nginx-container
+        image: nginx:1.29
+        ports:
+        - containerPort: 8000
+          name: http
+        lifecycle:
+          preStop:
+            exec:
+              command: ['sh', '-c', 'rm', '/homework/index.html']
+        volumeMounts:
+        - name: homework-volume
+          mountPath: /homework
+        - name: config
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+        - name: config-pairs
+          mountPath: /homework/conf
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 1
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 100Mi
+      volumes:
+      - name: homework-volume
+        persistentVolumeClaim:
+          claimName: web-server
+      - name: config
+        configMap:
+          name: nginx-config
+          items:
+          - key: default.conf
+            path: default.conf
+      - name: config-pairs
+        configMap:
+          name: nginx-config
+          items:
+          - key: key
+            path: key
+          - key: someKey
+            path: someKey

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  name: web-server
+  namespace: homework
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-server
+            port: 
+              name: http
+      - path: /homepage$
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: web-server
+            port:
+              name: http

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: custom-sc
+  resources:
+    requests:
+      storage: 200Mi

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-server
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app: web-server
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http

--- a/kubernetes-volumes/storageClass.yaml
+++ b/kubernetes-volumes/storageClass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: custom-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- создан манифест pvc.yaml, описывающий PersistentVolumeClaim, запрашивающий
хранилище с storageClass по-умолчанию
- создан манифест configmap.yaml для объекта типа configMap, описывающий
конфиг для nginx и дополнительный набор пар ключ-значение
- в манифесте deployment.yaml изменена спецификация volume типа emptyDir, 
который монтируется в init и основной контейнер, на pvc, созданный в 
предыдущем пункте
- в манифесте deployment.yaml добавлено монтирование ранее созданного configMap
как volume к основному контейнеру пода в директорию /homework/conf, так, чтобы 
его содержимое можно было получить, обратившись по url /conf/key
- `*` создан манифест storageClass.yaml, описывающий объкт типа storageClass с
provisioner k8s.io/minikube-hostpath и reclaimPolicy Retain
- `*` изменен манифест pvc.yaml так, чтобы в нем запрашивалось хранилище,
созданное в предыдущем пункте

## Как запустить проект:
 - применить все манифесты `kubectl apply -f namespace.yaml -f configmap.yaml -f storageClass.yaml -f pvc.yaml -f deployment.yaml -f service.yaml -f ingress.yaml`
 - для запуска на minikube нужно установить ingress-контроллер  `minikube addons enable ingress`
 - запустить тоннель `minikube tunnel --bind-address=127.0.0.1`
 - добавить хост `homework.otus` в `/etc/hosts`.

## Как проверить работоспособность:
 - перейти по адресу http://homework.otus
 - перейти по адресу http://homework.otus/conf/key
 
## PR checklist:
 - [x] Выставлен label с темой домашнего задания
